### PR TITLE
Implement force-downgrade to HTTP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:alpine AS build
 
 ENV CGO_ENABLED 0
 ENV GO111MODULE on
-ENV GOPROXY https://goproxy.io
+ENV GOPROXY https://proxy.golang.org,direct
 COPY --from=xgo / /
 
 ARG TARGETPLATFORM
@@ -22,10 +22,11 @@ RUN apk --update --no-cache add \
 
 # Compile the cmd to a standalone binary
 WORKDIR /app
-COPY . .
-RUN go mod vendor
-RUN go build -ldflags "-s -w -extldflags '-static'" ./cmd/proxy/
+COPY go.mod go.sum ./
+RUN go mod download
 
+COPY . .
+RUN go build -ldflags "-s -w -extldflags '-static'" ./cmd/proxy/
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:latest
 

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -21,7 +21,8 @@ import (
 func main() {
 	pflag.String("proxy_listen_addr", "0.0.0.0:8010", "Listen address for the http proxy")
 	pflag.String("proxyapi_listen_addr", "0.0.0.0:11000", "Listen address for the proxy API")
-	pflag.Bool("development", false, "Enable development logging")
+	pflag.Bool("verbose", false, "Enable verbose logging")
+	pflag.Bool("log_pretty_print", false, "Enable human readable log")
 	pflag.Bool("intercept_https", false, "Enable HTTPS interception")
 	pflag.Bool("force_http_downgrade", false, "Forces the use of HTTP when talking to the API")
 	pflag.Parse()
@@ -38,10 +39,14 @@ func main() {
 
 	// setup logging
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
-	if viper.GetBool("development") {
+	if viper.GetBool("verbose") {
 		zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	}
+
+	if viper.GetBool("log_pretty_print") {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339})
 	}
+
 	log.Logger = log.With().Timestamp().Str("log_type", "app").Str("app", "Proxy").Logger()
 
 	mainLogger := log.With().Str("module", "main").Logger()
@@ -59,6 +64,7 @@ func main() {
 		CertificateDirectory: "./cert/",
 		InterceptHttps:       viper.GetBool("intercept_https"),
 		ForceHttpDowngrade:   viper.GetBool("force_http_downgrade"),
+		Verbose:              viper.GetBool("verbose"),
 	})
 	httpProxy := swProxy.CreateProxy()
 

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -23,6 +23,7 @@ func main() {
 	pflag.String("proxyapi_listen_addr", "0.0.0.0:11000", "Listen address for the proxy API")
 	pflag.Bool("development", false, "Enable development logging")
 	pflag.Bool("intercept_https", false, "Enable HTTPS interception")
+	pflag.Bool("force_http_downgrade", false, "Forces the use of HTTP when talking to the API")
 	pflag.Parse()
 
 	viper.SetEnvPrefix("swarpf_proxy")
@@ -57,6 +58,7 @@ func main() {
 	swProxy := swproxy.New(apiEvents, swproxy.ProxyConfiguration{
 		CertificateDirectory: "./cert/",
 		InterceptHttps:       viper.GetBool("intercept_https"),
+		ForceHttpDowngrade:   viper.GetBool("force_http_downgrade"),
 	})
 	httpProxy := swProxy.CreateProxy()
 

--- a/pkg/swproxy/endpoints.go
+++ b/pkg/swproxy/endpoints.go
@@ -47,6 +47,41 @@ func (s proxyGameEndpointMatcher) matches(ctx *goproxy.ProxyCtx) bool {
 	return methodMatches && hostMatches
 }
 
+// Location Service Endpoint Matcher
+type locationServiceEndpointMatcher struct{}
+
+func newLocationServiceMatcher() *locationServiceEndpointMatcher {
+	return new(locationServiceEndpointMatcher)
+}
+
+func (s locationServiceEndpointMatcher) HandleReq(_ *http.Request, ctx *goproxy.ProxyCtx) bool {
+	return s.matches(ctx)
+}
+
+func (s locationServiceEndpointMatcher) HandleResp(_ *http.Response, ctx *goproxy.ProxyCtx) bool {
+	return s.matches(ctx)
+}
+
+func (s locationServiceEndpointMatcher) matches(ctx *goproxy.ProxyCtx) bool {
+	methodMatches := ctx.Req.Method == "GET"
+	hostMatches := strings.HasPrefix(ctx.Req.Host, "summonerswar-") &&
+		strings.HasSuffix(ctx.Req.Host, "qpyou.cn")
+	urlMatches := ctx.Req.URL.Path == "/api/location_c2.php"
+
+	if hostMatches {
+		log.Trace().
+			Str("log_type", "module").
+			Str("module", "locationServiceEndpointMatcher").
+			Str("host", ctx.Req.Host).
+			Stringer("url", ctx.Req.URL).
+			Str("method", ctx.Req.Method).
+			Bool("endpoint_matches", methodMatches && hostMatches).
+			Msg("Checking if endpoint matches")
+	}
+
+	return methodMatches && hostMatches && urlMatches
+}
+
 // // Game Endpoint Matcher
 // used to intercept requests from and to the Com2uS game server
 type gameEndpointMatcher struct{}

--- a/pkg/swproxy/proxy.go
+++ b/pkg/swproxy/proxy.go
@@ -222,6 +222,7 @@ func (p *Proxy) onLocationResponse(resp *http.Response, ctx *goproxy.ProxyCtx) *
 
 	// write modified body to response
 	resp.Body = ioutil.NopCloser(bytes.NewBuffer(modifiedBodyBytes))
+	resp.ContentLength = int64(len(modifiedBodyBytes))
 
 	responseLogger.Info().
 		Bytes("encryptedContent", modifiedBodyBytes).


### PR DESCRIPTION
This PR implements a way to forcibly downgrade connections to the game API to HTTP. It implements a command line parameter that can toggle said behavior.

It additionally fixes some issues with docker caching and introduces new command line parameters to that can lead to cleaner logging output.